### PR TITLE
Remove git ssh keys

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -50,10 +50,6 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
       - uses: actions/checkout@v4
-      - name: Set up SSH deploy key
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.AGENTEVAL_DEPLOY_KEY }}
 
       # Set up Docker Buildx for caching
       - name: Set up Docker Buildx
@@ -65,7 +61,6 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          ssh: default
           tags: astabench:latest
           cache-from: type=gha,scope=astabench  # Use GitHub Actions cache
           cache-to: type=gha,mode=max,scope=astabench

--- a/Makefile
+++ b/Makefile
@@ -32,29 +32,7 @@ endif
 # Build the Docker image (primary target)
 # -----------------------------------------------------------------------------
 build-image:
-	@echo "Building astabench image (GitHub token preferred, then SSH)..."
-	@sh -ec ' \
-	  TOKEN="$${GITHUB_TOKEN}"; \
-	  if [ -z "$$TOKEN" ] && command -v gh >/dev/null 2>&1; then \
-	    TOKEN="$$(gh auth token 2>/dev/null)"; \
-	  fi; \
-	  if [ -n "$$TOKEN" ]; then \
-	    echo "Using GitHub token via BuildKit secret"; \
-	    tmp=$$(mktemp); echo "$$TOKEN" > $$tmp; \
-	    DOCKER_BUILDKIT=1 docker build $(BUILD_QUIET) . \
-	      --tag $(ASTABENCH_TAG) \
-	      -f ./docker/Dockerfile \
-	      --secret id=github_token,src=$$tmp; \
-	    rm -f $$tmp; \
-	  elif [ -n "$$SSH_AUTH_SOCK" ]; then \
-	    echo "No GitHub token → falling back to SSH agent"; \
-	    DOCKER_BUILDKIT=1 docker build $(BUILD_QUIET) . \
-	      --tag $(ASTABENCH_TAG) \
-	      -f ./docker/Dockerfile \
-	      --ssh default; \
-	  else \
-	    echo "No GitHub token or SSH agent available → building without authentication"; \
-	  fi'
+	docker build $(BUILD_QUIET) . --tag $(ASTABENCH_TAG) -f ./docker/Dockerfile
 
 # -----------------------------------------------------------------------------
 # Interactive shell in container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,22 +35,8 @@ COPY pyproject.toml /astabench/
 # Create a basic directory structure for the package
 RUN mkdir -p /astabench/astabench
 
-# use BuildKit secret and optional SSH agent to auth private Git deps (token preferred)
-RUN --mount=type=secret,id=github_token,required=false \
-    --mount=type=ssh,required=false \
-    bash -euxo pipefail -c '\
-    # prefer GitHub token from secret, then ARG; fallback to SSH\n\
-    if [ -f /run/secrets/github_token ]; then \
-    TOKEN="$(cat /run/secrets/github_token)"; \
-    elif [ -n "${SSH_AUTH_SOCK:-}" ]; then \
-    git config --global url."git@github.com:".insteadOf "https://github.com/"; \
-    export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"; \
-    fi; \
-    if [ -n "${TOKEN:-}" ]; then \
-    git config --global url."https://$TOKEN@github.com/".insteadOf "https://github.com/"; \
-    fi; \
-    uv sync --extra litqa2; \
-    uv sync --extra dev --extra inspect_evals --extra anthropic --extra smolagents --extra e2e_discovery --inexact;'
+RUN uv sync --extra litqa2
+RUN uv sync --inexact --extra dev --extra inspect_evals --extra anthropic --extra smolagents --extra e2e_discovery
 
 COPY . /astabench
 


### PR DESCRIPTION
This repo does't have the `AGENTEVAL_DEPLOY_KEY` secret, but I think we can remove it, since the `agent-eval` repo is now public