### PR TITLE
bump agenteval to add openness and tool usage to submission

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "inspect_ai==0.3.106",
-    "agent-eval==0.1.10",
+    "agent-eval==0.1.13",
     "openai>=1.78.0", # required by inspect
     "pydantic>=2.11.4", # required by inspect
     "litellm",


### PR DESCRIPTION
```
(astabench) 12:29:01 ~/src/asta-bench rh-add-openness $ astabench lb publish --help
Usage: astabench lb publish [OPTIONS] LOG_DIR

  Publish scored results in log_dir to Hugging Face leaderboard.

Options:
  --submissions-repo-id TEXT    HF repo id for submissions. Defaults to
                                SUBMISSIONS_REPO_ID env var.
  --results-repo-id TEXT        HF repo id for result stats. Defaults to
                                RESULTS_REPO_ID env var.
  -o, --openness [c|api|os|ow]  Level of openness for the agent. Options: c
                                (Closed), api (API Available), os (Open
                                Source), ow (Open Source + Open Weights)
                                [required]
  -t, --tool-usage [s|css|c]    Tool choices available to the agent. Options:
                                s (Standard), css (Custom with Standard
                                Search), c (Fully Custom)  [required]
  --username TEXT               HF username/org for submission. Defaults to
                                your HF account name.
  --agent-name TEXT             Descriptive agent name for submission.
                                [required]
  --agent-description TEXT      Description of the agent being submitted.
  --agent-url TEXT              URL to the agent's repository or
                                documentation.
  --help                        Show this message and exit.
```