### PR TITLE
chore: bump inspect_ai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "inspect_ai==0.3.113",
+    "inspect_ai==0.3.114",
     "agent-eval==0.1.14",
     "openai>=1.78.0", # required by inspect
     "pydantic>=2.11.4", # required by inspect


### PR DESCRIPTION
Looks like a small patch to the `inspect log convert` command that we might as well pickup in case users use that command on their eval files. [Changelog](https://github.com/UKGovernmentBEIS/inspect_ai/blob/42c9aebffa0742ffa2e4841e1ed2f2d51f7c8020/CHANGELOG.md#L7)

I know we have https://github.com/allenai/astabench-issues/issues/275 @mdarcy220 and my thinking here is that it makes sense to pick up bugfixes at least before your general sweeps, while checking that there does not appear to dangerous changes to inspect that are likely to affect us.