### PR TITLE
Mitigate some possible sporadic issues

### DIFF
--- a/astabench/solvers/sandbox_util/sandbox_jupyter.py
+++ b/astabench/solvers/sandbox_util/sandbox_jupyter.py
@@ -22,17 +22,17 @@ from astabench.solvers.sandbox_util.static.sandbox_types import ChunkedResponse
 logger = logging.getLogger(__name__)
 
 
-class InternalTimeout(RuntimeError):
+class RuntimeInternalTimeout(RuntimeError):
     """Raised when we get a TimeoutError while calling an MCP tool.  The
     sandboxed mcp server shouldn't raise TimeoutError directly (preferring
     instead to provide a reasonable tool response explaining the timeout), so
     these errors mean an internal inspect_ai infra operation timed out.
     Usually this is when getting the inspect-tool-support version, which has
     a hard-coded timeout of 5 seconds. If the TimeoutError itself were allowed
-    to bubble up, InspectAI would try to score the sample anyway, which almost
-    never what we want.  Instead, we convert it to a RuntimeError which will be
-    treated as serious; either the whole eval will abort or the sample will be
-    retried, depending on configuration."""
+    to bubble up, InspectAI would try to score the sample anyway, which is
+    almost never what we want.  Instead, we convert it to a RuntimeError which
+    will be treated as serious; either the whole eval will abort or the sample
+    will be retried, depending on configuration."""
 
 
 @contextlib.contextmanager
@@ -40,7 +40,9 @@ def timeout_to_internal():
     try:
         yield
     except TimeoutError as e:
-        raise InternalTimeout("An internal sandbox MCP operation timed out") from e
+        raise RuntimeInternalTimeout(
+            "An internal sandbox MCP operation timed out"
+        ) from e
 
 
 class SandboxJupyter:
@@ -217,8 +219,8 @@ class SandboxJupyter:
                     continue
                 raise e
             except TimeoutError as e:
-                raise InternalTimeout(
-                    "An internal sandbox MCP operation timed out while initializing Jupyter tools. "
+                raise RuntimeInternalTimeout(
+                    "An internal sandbox MCP operation timed out while initializing Jupyter tools."
                 ) from e
 
         for tool in jupyter_tools:


### PR DESCRIPTION
Looking at some logs from the last test run, I see a couple timeout errors; some retried but some seem to have gotten scored (seems to depend on where the timeout happens), which isn't what we want.  This isn't a perfect solution but if we just turn them all into RuntimeErrors then the retry mechanism can take care of the rest.