### PR TITLE
Clarify submission process in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,21 @@ astabench publish logs/2025-01-15-myagent-run/ \
   --submissions-repo-id allenai/asta-bench-internal-submissions
 
 # Output: hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/validation/username_MyAgent_2025-01-01T00-00-00
+# This step generates a submission.json file with your agent name, description and details and includes the file with your logs and config in the submissions repo
 
 # Step 2. Score the remote submission (use path from step 1).
 astabench score hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/validation/username_MyAgent_2025-01-01T00-00-00
+# This will write files scores.json and summary_stats.json to a summaries directory in the submissions repo; the scores file is needed in this location to publish results to leaderboard
 
 # Step 3. Publish data to display in the leaderboard UI.
 astabench lb publish hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/validation/username_MyAgent_2025-01-01T00-00-00
+# This step expects eval_config.json and submission.json to be available in your submission files and scores.json to be present in the submission summaries directory. It integrates these files for publication to the leaderboard.
 ```
 
 Note to Ai2 internal users: Steps 2 and 3 may be run centrally, e.g. to re-score with up-to-date costs and make controlled updates to leaderboard display data.
+
+For bulk runs of already scored results, it is possible to run:
+`cat filenames_to_publish.txt | xargs astabench lb publish`
 
 ### Parallelism and system requirements
 


### PR DESCRIPTION
Adjust README to match revised CLI submission flows from `agent-eval` [changes](https://github.com/allenai/agent-eval/pull/30)