### PR TITLE
Tools for publishing to pypi

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+          fetch-depth: 0
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      
+      - name: Verify version matches pyproject.toml
+        run: |
+          PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          INPUT_VERSION="${{ inputs.version }}"
+          if [ "$PYPROJECT_VERSION" != "$INPUT_VERSION" ]; then
+            echo "pyproject.toml has version '$PYPROJECT_VERSION' at git tag v'$INPUT_VERSION'"
+            echo "Use 'make tag' to ensure the versions match"
+            exit 1
+          fi
+
+      - name: Build package
+        run: |
+          uv build
+      
+      - name: Verify build
+        run: |
+          ls -la dist/
+          echo "Built packages:"
+          ls dist/
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          print-hash: true
+      

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,9 @@
+# Development
+
+Instructions for developers working on the project.
+
+## Publishing a new version
+
+  1. Increment the version number in `pyproject.toml`
+  2. Run `make tag` to push the new version tag to GitHub
+  3. Go to https://github.com/allenai/asta-bench/actions and run the `Publish to PyPI` workflow, using the new version number

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: shell format mypy flake test build-image test-expensive
+.PHONY: shell format mypy flake test build-image test-expensive tag
 
 # allow passing extra pytest args, e.g. make test-expensive PYTEST_ARGS="-k EVAL_NAME"
 PYTEST_ARGS ?=
@@ -127,3 +127,9 @@ endif
 test-expensive:
 	@$(TEST_RUN) uv run --no-sync --extra dev --extra inspect_evals --extra smolagents \
 		-m pytest $(PYTEST_ARGS) -vv -o addopts= -m expensive /astabench/tests
+
+tag:
+	@VERSION=$$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/'); \
+	echo "Creating and pushing tag v$$VERSION"; \
+	git tag "v$$VERSION" && \
+	git push origin "v$$VERSION"


### PR DESCRIPTION
Tools and docs for publishing to pypi (Did this [once](https://pypi.org/project/astabench/) manually already)

I plan to publish some package versions in advance of making the repo public for testing `agent-baselines` and `asta-bench-private`

https://github.com/allenai/astabench-issues/issues/283