### PR TITLE
Git dependencies

### DIFF
--- a/.github/workflows/inspect-evals-pyproject.toml
+++ b/.github/workflows/inspect-evals-pyproject.toml
@@ -1,0 +1,172 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools_scm]
+
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["inspect_evals*"]
+
+[tool.setuptools.package-data]
+"inspect_evals" = ["listing.yaml"]
+
+
+[tool.ruff]
+extend-exclude = [
+    "docs",
+    "src/inspect_evals/cybench/challenges",
+    "src/inspect_evals/cyberseceval_2/vulnerability_exploit/challenges",
+]
+src = ["src"]
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # flake8
+    "D",      # pydocstyle
+    "I",      # isort
+    "SIM101", # duplicate isinstance
+    "UP038",  # non-pep604-isinstance
+    # "RET", # flake8-return
+    # "RUF", # ruff rules
+]
+ignore = ["E203", "E501", "D10", "D212", "D415"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-rA --doctest-modules --color=yes -m 'not dataset_download'"
+testpaths = ["tests"]
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
+norecursedirs = [
+    "tests/test_helpers",
+    "tests/test_package",
+    "tests/test_task_list",
+]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+log_level = "warning"
+markers = [
+    "dataset_download: marks tests that download datasets (deselect with '-m \"not dataset_download\"')", # (disabled by default)
+    "huggingface: marks tests that depend on downloading a model from Hugging Face",
+]
+
+[tool.mypy]
+exclude = [
+    "build",
+    "(?:^|/)_resources/",
+    "src/inspect_evals/gdm_capabilities/in_house_ctf/challenges",
+    "src/inspect_evals/cyberseceval_2/vulnerability_exploit/challenges",
+    "src/inspect_evals/swe_bench/tests",
+    "src/inspect_evals/cybench",
+]
+warn_unused_ignores = true
+no_implicit_reexport = true
+strict_equality = true
+warn_redundant_casts = true
+warn_unused_configs = true
+# This mypy_path config is a bit odd, it's included to get mypy to resolve
+# imports correctly in test files. For example, imports such as
+# `from test_helpers.utils import ...` fail mypy without this configuration,
+# despite actually working when running tests.
+#
+# Revisit this if it interferes with mypy running on `src`  due to name
+# conflicts, but that will hopefully be unlikely.
+mypy_path = "tests"
+
+[[tool.mypy.overrides]]
+module = ["inspect_evals.*"]
+warn_return_any = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+extra_checks = true
+disable_error_code = "unused-ignore"
+
+[tool.check-wheel-contents]
+ignore = ["W002", "W009"]
+
+[project]
+name = "astabench-inspect_evals"
+version = "0.0.2"
+authors = [{ name = "UK AI Security Institute" }]
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT License" }
+dynamic = ["version", "dependencies"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Source Code" = "https://github.com/UKGovernmentBEIS/inspect_evals"
+"Issue Tracker" = "https://github.com/UKGovernmentBEIS/inspect_evals/issues"
+
+[project.entry-points.inspect_ai]
+inspect_evals = "inspect_evals._registry"
+
+
+[project.optional-dependencies]
+swe_bench = ["swebench>=3.0.15", "docker"]
+mathematics = ["sympy", "antlr4-python3-runtime==4.13.2"]
+mle_bench = ["mlebench@git+https://github.com/openai/mle-bench.git", "docker"]
+worldsense = ["pandas"]
+mind2web = ["lxml", "lxml-stubs"]
+sevenllm = ["jieba==0.42.1", "sentence_transformers==3.4.1", "rouge==1.0.1"]
+scicode = ["gdown"]
+livebench = ["liveBench@git+https://github.com/MattFisher/LiveBench.git@py311-compat", "nltk"]
+ifeval = [
+    "instruction_following_eval@git+https://github.com/josejg/instruction_following_eval",
+]
+core_bench = ["scipy"]
+
+dev = [
+    "inspect_ai@git+https://github.com/UKGovernmentBEIS/inspect_ai",
+    "anthropic",
+    "mypy",
+    "openai",
+    "pandas",
+    "pandas-stubs",
+    "pre-commit",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-dotenv",
+    "pytest-xdist",
+    "pyyaml",
+    "ruff==0.11.2",  # match version specified in .pre-commit-config.yaml and .github/workflows/build.yml
+    "types-Pillow",
+    "types-PyYAML",
+    "types-requests",
+]
+test = [
+    "inspect_evals[dev]",
+    "inspect_evals[sevenllm]",
+    "inspect_evals[core_bench]",
+    "inspect_evals[mind2web]",
+    "inspect_evals[livebench]",
+    "inspect_evals[usaco]",
+]
+doc = ["quarto-cli", "jupyter"]
+dist = ["twine", "build"]

--- a/.github/workflows/knowledge-storm-setup.py
+++ b/.github/workflows/knowledge-storm-setup.py
@@ -1,0 +1,38 @@
+import re
+
+from setuptools import setup, find_packages
+
+# Read the content of the README file
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+    # Remove p tags.
+    pattern = re.compile(r"<p.*?>.*?</p>", re.DOTALL)
+    long_description = re.sub(pattern, "", long_description)
+
+# Read the content of the requirements.txt file
+with open("requirements.txt", encoding="utf-8") as f:
+    requirements = f.read().splitlines()
+
+
+setup(
+    name="astabench-knowledge-storm",
+    version="0.0.2",
+    author="Yijia Shao, Yucheng Jiang",
+    author_email="shaoyj@stanford.edu, yuchengj@stanford.edu",
+    description="STORM: A language model-powered knowledge curation engine.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/stanford-oval/storm",
+    license="MIT License",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    python_requires=">=3.10",
+    install_requires=requirements,
+)

--- a/.github/workflows/publish-inspect-evals.yml
+++ b/.github/workflows/publish-inspect-evals.yml
@@ -1,0 +1,58 @@
+name: Publish inspect_evals to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+      - name: Checkout inspect_evals repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'UKGovernmentBEIS/inspect_evals'
+          ref: 'c2bec9ebee7a5995512bf5ff67a2e82afe4d12e1'
+          fetch-depth: 0
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+      
+      - name: Replace pyproject.toml
+        run: |
+          # Copy our custom pyproject.toml from the workflow directory
+          curl -s "https://raw.githubusercontent.com/${{ github.repository }}/main/.github/workflows/inspect-evals-pyproject.toml" -o pyproject.toml
+
+      - name: Install package dependencies
+        run: |
+          # Install the package in editable mode to resolve dependencies
+          python -m pip install -e .
+      
+      - name: Build package
+        run: |
+          python -m build
+      
+      - name: Verify build
+        run: |
+          ls -la dist/
+          echo "Built packages:"
+          ls dist/
+          # Check package contents
+          python -m twine check dist/*
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          print-hash: true

--- a/.github/workflows/publish-knowledge-storm.yml
+++ b/.github/workflows/publish-knowledge-storm.yml
@@ -1,0 +1,68 @@
+name: Publish knowledge-storm to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+      - name: Checkout knowledge-storm repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'gituser768/storm'
+          ref: 'dh-fix-youcom'
+          fetch-depth: 0
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+      
+      - name: Replace setup.py
+        run: |
+          echo "Replacing setup.py with custom template..."
+          # Copy our custom setup.py from the workflow directory
+          curl -s "https://raw.githubusercontent.com/${{ github.repository }}/main/.github/workflows/knowledge-storm-setup.py" -o setup.py
+          # Replace version placeholder
+          sed -i 's/PLACEHOLDER_VERSION/${{ inputs.version }}/' setup.py
+          echo "Custom setup.py:"
+          cat setup.py
+      
+      - name: Install package dependencies
+        run: |
+          # Install the package in editable mode to resolve dependencies
+          python -m pip install -e .
+      
+      - name: Build package
+        run: |
+          python -m build
+      
+      - name: Verify build
+        run: |
+          ls -la dist/
+          echo "Built packages:"
+          ls dist/
+          # Check package contents
+          python -m twine check dist/*
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          print-hash: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,11 +2,6 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 1.0.0)'
-        required: true
-        type: string
 
 jobs:
   publish:
@@ -17,10 +12,16 @@ jobs:
       contents: write
     
     steps:
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+      
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: v${{ inputs.version }}
           fetch-depth: 0
       
       - name: Set up Python
@@ -28,20 +29,20 @@ jobs:
         with:
           python-version: '3.11'
       
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-      
       - name: Verify version matches pyproject.toml
         run: |
           PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          INPUT_VERSION="${{ inputs.version }}"
+          INPUT_VERSION="${{ steps.get_version.outputs.version }}"
           if [ "$PYPROJECT_VERSION" != "$INPUT_VERSION" ]; then
             echo "pyproject.toml has version '$PYPROJECT_VERSION' at git tag v'$INPUT_VERSION'"
             echo "Use 'make tag' to ensure the versions match"
             exit 1
           fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: false
 
       - name: Build package
         run: |
@@ -56,6 +57,5 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           print-hash: true
       

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,4 +6,25 @@ Instructions for developers working on the project.
 
   1. Increment the version number in `pyproject.toml`
   2. Run `make tag` to push the new version tag to GitHub
-  3. Go to https://github.com/allenai/asta-bench/actions and run the `Publish to PyPI` workflow, using the new version number
+  3. Go to https://github.com/allenai/asta-bench/actions and run the `Publish to PyPI` workflow, using the version tag
+
+## Updating git dependencies
+
+PyPI does not allow git dependencies to be specified in `pyproject.toml`. 
+We depend on specific git shas of some dependencies, which we publish to our own pypi account
+
+### Updating inspect_evals
+
+  1. Update the git ref in the checkout step of [publish-inspect-evals.yml](.github/workflows/publish-inspect-evals.yml).
+  2. Check out that git ref locally and copy its `pyproject.toml` to [.github/workflows/inspect-evals-pyproject.toml](.github/workflows/inspect-evals-pyproject.toml).
+  3. Change the `name = "..."` in `inspect-evals-pyproject.toml` to `astabench-inspect_evals`
+  3. Bump the `version = "..."` in `inspect-evals-pyproject.toml` to the current version of astabench 
+  4. Go to https://github.com/allenai/asta-bench/actions and run the "Publish inspect_evals to PyPI" workflow
+
+### Updating knowledge-storm
+  1. Update the git ref in the checkout step of [publish-knowledge-storm.yml](.github/workflows/publish-knowledge-storm.yml).
+  2. Check out that git ref locally and copy its `setup.py` to [.github/workflows/knowledge-storm-setup.py](.github/workflows/knowledge-storm-setup.py).
+  3. Change the `name="..."` in `knowledge-storm-setup.py` to `astabench-knowledge-storm`
+  3. Bump the `version="..."` in `knowledge-storm-setup.py` to the current version of astabench
+  4. Go to https://github.com/allenai/asta-bench/actions and run the "Publish knowledge-storm to PyPI" workflow
+


### PR DESCRIPTION
https://github.com/allenai/astabench-issues/issues/283

PyPI does not allow git dependencies. Publish our own versions of `inspect_evals` and `knowledge-storm` so we can declare them as dependencies. Make a workflow file for each, which contains the specific git sha we will publish from. Need to manually override the name/version, which is done by making a static copy of the pyproject.toml/setup.py. Add docs for this procedure.

Not pretty! The only alternative I can think of is to fork the repos, modify the pyproject.toml in the fork, and add the workflow files there. I prefer this approach (slightly) because it keeps all of the activity in this repo. However, if we ever have another project that depends on those same sha-specific dependencies, then publishing from the fork seems like the only option.