### PR TITLE
Bump agent eval version to 0.1.41

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "agent-eval==0.1.41",
     "openai>=1.78.0", # required by inspect
     "pydantic>=2.11.4", # required by inspect
-    "litellm,
+    "litellm",
     "datasets~=3.2.0",
     "huggingface_hub",
     "google-genai>=1.16.1",


### PR DESCRIPTION
To pick up https://github.com/allenai/agent-eval/pull/63, https://github.com/allenai/agent-eval/pull/64, https://github.com/allenai/agent-eval/pull/65.