### PR TITLE
Remove solver-specific docker targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,6 @@ ENV_ARGS :=
 
 # Docker target for running a shell
 TARGET := --target astabench-base
-# Name of solver to build Docker container for
-SOLVER :=
-ifdef SOLVER
-  TARGET := --target $(SOLVER)
-  ASTABENCH_TAG := $(ASTABENCH_TAG)-$(SOLVER)
-endif
 
 # Add each env var only if it's defined
 ifdef OPENAI_API_KEY

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,26 +40,3 @@ COPY . /astabench
 
 # Sync after copy to register `inspect_evals` and `astabench` tasks/tools/cli
 RUN uv sync --extra dev
-
-
-# Images for running specific solvers
-FROM astabench-base AS react
-RUN solvers/react/setup.sh
-
-FROM astabench-base AS smolagents
-RUN solvers/smolagents/setup.sh
-
-FROM astabench-base AS storm
-RUN solvers/storm/setup.sh
-
-FROM astabench-base AS sqa
-RUN solvers/sqa/setup.sh
-
-FROM astabench-base AS super
-RUN solvers/super/setup.sh
-
-FROM astabench-base AS datavoyager
-RUN solvers/datavoyager/setup.sh
-
-FROM astabench-base AS futurehouse
-RUN solvers/futurehouse/setup.sh


### PR DESCRIPTION
This repo now should only have a generic `make shell` target. Solver-specific ones are available in `agent-baselines`