### PR TITLE
Bump agent-eval version to 0.1.43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "inspect_ai==0.3.114",
-    "agent-eval==0.1.42",
+    "agent-eval==0.1.43",
     "openai>=1.78.0", # required by inspect
     "pydantic>=2.11.4", # required by inspect
     "litellm",


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/469. Picks up the change in asta-bench.