### PR TITLE
Bump inspect_ai to 0.3.203 and agent-eval to 0.1.47

### DIFF
--- a/astabench/tools/native_provider_tools.py
+++ b/astabench/tools/native_provider_tools.py
@@ -60,7 +60,7 @@ def make_native_search_tools(inserted_before: str | None = None) -> list[Tool]:
     elif isinstance(model.api, AnthropicAPI):
         tool = web_search({"anthropic": True})
         tool_info = parse_tool_info_with_options(tool)
-        if model.api.web_search_tool_param(tool_info) is not None:
+        if model.api.web_search_tool_params(tool_info) is not None:
             return [tool]
     elif isinstance(model.api, GoogleGenAIAPI):
         tool = web_search({"gemini": True})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astabench"
-version = "0.5.2"
+version = "0.5.3"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "inspect_ai==0.3.114",
-    "agent-eval[leaderboard]==0.1.46",
+    "inspect_ai==0.3.203",
+    "agent-eval[leaderboard]==0.1.47",
     "openai>=2.30.0", # provider SDK version validated with the current model set
     "pydantic>=2.11.4", # required by inspect
     "litellm==1.82.3",

--- a/tests/tools/test_native_provider_tools.py
+++ b/tests/tools/test_native_provider_tools.py
@@ -104,7 +104,7 @@ class TestNativeProviderTools:
         # Mock the model
         mock_model = Mock()
         mock_model.api = Mock(spec=AnthropicAPI)
-        mock_model.api.web_search_tool_param.return_value = {
+        mock_model.api.web_search_tool_params.return_value = {
             "name": "web_search",
             "type": "web_search_20250305",
         }
@@ -128,7 +128,7 @@ class TestNativeProviderTools:
         assert result == [mock_tool]
         mock_web_search.assert_called_once_with({"anthropic": True})
         mock_parse_tool_info.assert_called_once_with(mock_tool)
-        mock_model.api.web_search_tool_param.assert_called_once_with(mock_tool_info)
+        mock_model.api.web_search_tool_params.assert_called_once_with(mock_tool_info)
 
     @patch("astabench.tools.native_provider_tools.get_model")
     def test_anthropic_web_search_tool_not_supported(self, mock_get_model):
@@ -136,7 +136,7 @@ class TestNativeProviderTools:
         # Mock the model
         mock_model = Mock()
         mock_model.api = Mock(spec=AnthropicAPI)
-        mock_model.api.web_search_tool_param.return_value = None  # Tool not supported
+        mock_model.api.web_search_tool_params.return_value = None  # Tool not supported
         mock_model.name = "claude-2"  # Assume this model doesn't support web search
         mock_get_model.return_value = mock_model
 
@@ -205,7 +205,7 @@ class TestNativeProviderTools:
         """Test that Anthropic web search tool properly validates and uses options."""
         mock_model = Mock()
         mock_model.api = Mock(spec=AnthropicAPI)
-        mock_model.api.web_search_tool_param.return_value = {
+        mock_model.api.web_search_tool_params.return_value = {
             "name": "web_search",
             "type": "web_search_20250305",
         }


### PR DESCRIPTION
following https://github.com/allenai/agent-eval/pull/77 part of the path to https://github.com/allenai/nora-issues/issues/2720

## Summary

- Bump \`inspect_ai\` from \`0.3.114\` to \`0.3.203\`
- Bump \`agent-eval\` from \`0.1.46\` to \`0.1.47\`
- Bump \`astabench\` version to \`0.5.3\`

\`inspect_ai 0.3.203\` is the minimum version that correctly plumbs reasoning parameters for all four target models in our current eval suite. See allenai/nora-issues#2720 for full context and allenai/nora-issues#2733 for the schema compatibility issues resolved by this upgrade.

\`agent-eval 0.1.47\` adds \`dirty: bool\` and \`total_cost: float64\` schema fields required to load leaderboard results produced by \`inspect_ai >= 0.3.137\`.

## Codebase realignment for inspect_ai 0.3.203

**\`AnthropicAPI.web_search_tool_param\` → \`web_search_tool_params\`** — The method was renamed from singular to plural in 0.3.203, and now returns \`list[...] | None\` instead of a single param. Updated both the call site in \`native_provider_tools.py\` and all mocks in \`tests/tools/test_native_provider_tools.py\`.

## Test plan

- [x] All unit tests pass (CI)
- [x] made baselines depend on this brnach, running short eval https://github.com/allenai/agent-baselines/commit/115bd5859e27731316b5eda6624243cedb4c28f0

🤖 Generated with [Claude Code](https://claude.com/claude-code)