### PR TITLE
Add paper citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,90 @@
+cff-version: 1.2.0
+message: "If you use AstaBench, please cite the following paper."
+title: "AstaBench: Rigorous Benchmarking of AI Agents with a Scientific Research Suite"
+preferred-citation:
+  type: conference-paper
+  title: "AstaBench: Rigorous Benchmarking of AI Agents with a Scientific Research Suite"
+  year: 2026
+  url: "https://openreview.net/forum?id=M7TNf5J26u"
+  collection-title: "The Fourteenth International Conference on Learning Representations"
+  conference:
+    name: "ICLR"
+  authors:
+    - given-names: Jonathan
+      family-names: Bragg
+    - given-names: Mike
+      family-names: D'Arcy
+    - given-names: Nishant
+      family-names: Balepur
+    - given-names: Dan
+      family-names: Bareket
+    - given-names: Bhavana
+      family-names: Dalvi Mishra
+    - given-names: Sergey
+      family-names: Feldman
+    - given-names: Dany
+      family-names: Haddad
+    - given-names: Jena D.
+      family-names: Hwang
+    - given-names: Peter
+      family-names: Jansen
+    - given-names: Varsha
+      family-names: Kishore
+    - given-names: Bodhisattwa Prasad
+      family-names: Majumder
+    - given-names: Aakanksha
+      family-names: Naik
+    - given-names: Sigal
+      family-names: Rahamimov
+    - given-names: Kyle
+      family-names: Richardson
+    - given-names: Amanpreet
+      family-names: Singh
+    - given-names: Harshit
+      family-names: Surana
+    - given-names: Aryeh
+      family-names: Tiktinsky
+    - given-names: Rosni
+      family-names: Vasu
+    - given-names: Guy
+      family-names: Wiener
+    - given-names: Chloe
+      family-names: Anastasiades
+    - given-names: Stefanus
+      family-names: Candra
+    - given-names: Jason
+      family-names: Dunkelberger
+    - given-names: Daniel
+      family-names: Emery
+    - given-names: Rob
+      family-names: Evans
+    - given-names: Malachi
+      family-names: Hamada
+    - given-names: Regan
+      family-names: Huff
+    - given-names: Rodney
+      family-names: Kinney
+    - given-names: Matt
+      family-names: Latzke
+    - given-names: Jaron
+      family-names: Lochner
+    - given-names: Ruben
+      family-names: Lozano-Aguilera
+    - given-names: Ngoc-Uyen
+      family-names: Nguyen
+    - given-names: Smita
+      family-names: Rao
+    - given-names: Amber
+      family-names: Tanaka
+    - given-names: Brooke
+      family-names: Vlahos
+    - given-names: Peter
+      family-names: Clark
+    - given-names: Doug
+      family-names: Downey
+    - given-names: Yoav
+      family-names: Goldberg
+    - given-names: Ashish
+      family-names: Sabharwal
+    - given-names: Daniel S.
+      family-names: Weld

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ AstaBench builds on top of the [InspectAI](https://inspect.ai-safety-institute.o
 - [Available Agents](#available-agents)
 - [Running ScholarQA evaluations with dvc](#running-scholarqa-evaluations-with-dvc)
 - [Terminology](#terminology)
+- [Citation](#citation)
 
 ## Quickstart
 
@@ -400,3 +401,27 @@ We generally follow the InspectAI terminology, but use some terms interchangeabl
 - A "scorer" is a function that takes a task state (after the solver has finished) and a target and returns one or more metrics.
 - A "task" or "benchmark" consists of a dataset (one or more problems) + a scorer
 - A "solver" or "agent" is a function that takes a task state (containing the problem input, possibly metadata/tools), potentially calls tools, and alters the state to indicate its answer (i.e. via `state.output.completion`).  Note: in these docs we generally use "solver" and "agent" interchangeably, despite them having slightly different meanings in InspectAI.
+
+## Citation
+
+If you use AstaBench, please cite the [AstaBench paper](https://openreview.net/forum?id=M7TNf5J26u):
+
+```bibtex
+@inproceedings{astabench,
+  title     = {Asta{B}ench: Rigorous Benchmarking of {AI} Agents with a Scientific Research Suite},
+  author    = {Jonathan Bragg and Mike D'Arcy and Nishant Balepur and Dan Bareket and
+               Bhavana Dalvi Mishra and Sergey Feldman and Dany Haddad and Jena D. Hwang and
+               Peter Jansen and Varsha Kishore and Bodhisattwa Prasad Majumder and
+               Aakanksha Naik and Sigal Rahamimov and Kyle Richardson and Amanpreet Singh and
+               Harshit Surana and Aryeh Tiktinsky and Rosni Vasu and Guy Wiener and
+               Chloe Anastasiades and Stefanus Candra and Jason Dunkelberger and
+               Daniel Emery and Rob Evans and Malachi Hamada and Regan Huff and
+               Rodney Kinney and Matt Latzke and Jaron Lochner and Ruben Lozano-Aguilera and
+               Ngoc-Uyen Nguyen and Smita Rao and Amber Tanaka and Brooke Vlahos and
+               Peter Clark and Doug Downey and Yoav Goldberg and Ashish Sabharwal and
+               Daniel S. Weld},
+  booktitle = {The Fourteenth International Conference on Learning Representations},
+  year      = {2026},
+  url       = {https://openreview.net/forum?id=M7TNf5J26u},
+}
+```


### PR DESCRIPTION
## Summary
- Add `CITATION.cff` so GitHub renders a "Cite this repository" widget
- Add a **Citation** section to the README (TOC entry + BibTeX) pointing to the AstaBench paper (ICLR 2026, https://openreview.net/forum?id=M7TNf5J26u)