### PR TITLE
Set insertion_date Sample metadata on cutoff-bearing tasks

### DIFF
--- a/astabench/evals/arxivdigestables/task.py
+++ b/astabench/evals/arxivdigestables/task.py
@@ -21,6 +21,9 @@ from astabench.evals.arxivdigestables.prompts import (
 )
 from astabench.evals.utils import not_implemented_solver
 from astabench.tools import make_asta_mcp_tools, table_editor
+from astabench.util.sample import set_insertion_date
+
+INSERTED_BEFORE = "2026-01-01"
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +164,7 @@ def setup_snippet_tool() -> Solver:
     # from the tool (no reason for the model to see it); it doesn't really
     # matter since we are also forcing the corpus ids, which are all older than
     # 2025 for this task
-    base_tools = make_asta_mcp_tools(insertion_date="2026-01-01")
+    base_tools = make_asta_mcp_tools(insertion_date=INSERTED_BEFORE)
     tools_by_name = {ToolDef(tool).name: tool for tool in base_tools}
 
     if "snippet_search" not in tools_by_name:
@@ -287,13 +290,15 @@ def arxivdigestables(
                 },
             )
         )
+    dataset = MemoryDataset(formatted_dataset)
+    set_insertion_date(dataset, INSERTED_BEFORE)
     tool_setups = []
     if with_snippet_search_tool:
         tool_setups.append(setup_snippet_tool())
     if with_table_editor_tool:
         tool_setups.append(use_tools(table_editor()))
     return Task(
-        dataset=MemoryDataset(formatted_dataset),
+        dataset=dataset,
         setup=tool_setups or None,
         solver=not_implemented_solver(),
         scorer=score_tables(unroller_model, scorer_model),

--- a/astabench/evals/labbench/litqa2/task.py
+++ b/astabench/evals/labbench/litqa2/task.py
@@ -34,6 +34,7 @@ from astabench.evals.utils import (
     not_implemented_solver,
 )
 from astabench.tools import make_asta_mcp_tools, make_native_search_tools
+from astabench.util.sample import set_insertion_date
 
 # See https://github.com/allenai/nora-issues-research/issues/98#issuecomment-2878244637
 # Set to one day later than the min insertion date of 2024-10-16
@@ -244,6 +245,7 @@ def litqa2_inspect(
     # "unsure" letter.
     rng = random.Random(seed)
     dataset = MemoryDataset([json_to_sample(d, rng) for d in data])
+    set_insertion_date(dataset, INSERTED_BEFORE)
 
     tool_setups = []
     if with_search_tools:

--- a/astabench/evals/paper_finder/task.py
+++ b/astabench/evals/paper_finder/task.py
@@ -35,6 +35,7 @@ from astabench.evals.paper_finder.paper_finder_utils import (
 )
 from astabench.evals.utils import not_implemented_solver
 from astabench.tools import make_asta_mcp_tools, make_native_search_tools
+from astabench.util.sample import set_insertion_date
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +247,7 @@ def paper_finder(
     dataset = load_paper_finder_bench(chosen_split)
     tool_setups = []
     inserted_before = get_inserted_before_per_dataset_type(chosen_split)
+    set_insertion_date(dataset, inserted_before)
     if with_search_tools:
         tool_setups.append(
             use_tools(

--- a/astabench/evals/sqa/task.py
+++ b/astabench/evals/sqa/task.py
@@ -34,6 +34,7 @@ from astabench.evals.sqa.rubric import (
 from astabench.evals.sqa.split_sentences import add_missing_citations
 from astabench.evals.utils import not_implemented_solver
 from astabench.tools import make_asta_mcp_tools, make_native_search_tools, report_editor
+from astabench.util.sample import set_insertion_date
 from astabench.types.sqa import SQAResponseWithTable
 
 logger = logging.getLogger(__name__)
@@ -496,6 +497,8 @@ def sqa(
         logger.warning(
             f"Unknown split {split}. No inserted_before date will be set for search tools."
         )
+    if inserted_before:
+        set_insertion_date(json_dataset, inserted_before)
     if with_search_tools:
         tool_setups.append(
             use_tools(make_asta_mcp_tools(insertion_date=inserted_before))

--- a/astabench/util/sample.py
+++ b/astabench/util/sample.py
@@ -1,0 +1,18 @@
+"""Sample-level helpers for asta-bench tasks."""
+
+from inspect_ai.dataset import Dataset
+
+
+def set_insertion_date(dataset: Dataset, insertion_date: str) -> Dataset:
+    """Set ``metadata["insertion_date"]`` on every sample in ``dataset``
+    (mutates in place; existing values are preserved).
+
+    Lets non-MCP agent surfaces (e.g. CLI-based agents that read host env
+    vars before launching their sandbox) mirror the same cutoff astabench's
+    MCP wrapper applies via ``make_asta_mcp_tools(insertion_date=...)``.
+    """
+    for sample in dataset:
+        meta = dict(sample.metadata or {})
+        meta.setdefault("insertion_date", insertion_date)
+        sample.metadata = meta
+    return dataset


### PR DESCRIPTION
## Summary

Each cutoff-bearing paper-search task (the ones that pass `insertion_date=...` to `make_asta_mcp_tools`) now sets `state.metadata["insertion_date"]` on every sample. This lets non-MCP agent surfaces (e.g. CLI-based agents that need to seed env vars before launching their sandbox) mirror the same cutoff astabench's MCP wrapper applies via `make_asta_mcp_tools(insertion_date=...)`.

Adds a small helper `astabench.util.sample.set_insertion_date(dataset, date)` and calls it from each cutoff-bearing task's base function (`litqa2_inspect`, `arxivdigestables`, `sqa`, `paper_finder`) using that task's existing cutoff value — no dates are introduced or modified. All registered split variants (`*_validation`, `*_test`, `*_dev`, paper_finder's litqa2 family) inherit the stamping automatically, including any future splits that route through the same base functions.

No behavior change for the MCP path. Tasks without a cutoff (code/data tasks) are untouched.

Needed by: harnesses that wrap CLI-based agents (e.g. agent-baselines inspect_swe baseline) and need per-sample cutoff dates without parsing task internals.