### PR TITLE
Raise Anthropic SDK floor for Inspect bridge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,11 @@ dependencies = [
     "h2~=4.2.0",
     "pandas",
     "scipy",
-    "anthropic>=0.87.0",
+    # inspect_ai's Anthropic bridge rejects older SDKs at runtime. Keep the
+    # declared floor aligned with that runtime requirement so frozen eval
+    # environments cannot resolve a combination that installs successfully
+    # and then fails before the first sample.
+    "anthropic>=0.105.0",
     "platformdirs",
     "numpy",
 ]


### PR DESCRIPTION
Raise the declared Anthropic SDK floor to the version enforced at runtime by the pinned Inspect bridge. This prevents frozen eval environments from resolving `anthropic==0.97.0`, installing successfully, and then failing before the first sample because Inspect requires at least 0.105.0.\n\nValidation: `uv run --isolated --with . python -c ...` resolves `anthropic==0.120.2` with the pinned `inspect-ai==0.3.233`.\n\nTracked by allenai/gas2own#430.