### PR TITLE
Relax solve-environment inspect_ai constraint to >=0.3.233,<0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,32 +8,26 @@ version = "0.5.4"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # SOLVE ARM inspect_ai floor. This is deliberately the shared floor that
-    # agent-baselines' inspect-swe declares (`inspect_ai>=0.3.249`), so the two
-    # cohere instead of fighting. The current Claude Code and Codex inspect_swe
-    # agents need >=0.3.249 for (a) the Anthropic sandbox bridge to accept a
-    # system-role message in `messages[]` (folded into ChatMessageSystem in
-    # messages_from_anthropic_input; older raised "Unexpected message role:
-    # system") and (b) the newer `checkpointer` bridge API that inspect_swe
-    # >=0.2.65 passes. Both earlier fixes this pin carried are still present at
-    # >=0.3.249: bridged MCP result serialization (0.3.220) and inline
-    # Anthropic system-role messages (0.3.233).
+    # SOLVE-ENVIRONMENT inspect_ai floor. The root astabench package is
+    # installed alongside a participant's solver to provide the benchmark
+    # tasks. It should declare the oldest inspect_ai API astabench itself needs
+    # and allow each solver to select a newer compatible version. Version
+    # 0.3.233 is the oldest release carrying both fixes required by these
+    # tasks: bridged MCP result serialization (0.3.220) and inline Anthropic
+    # system-role messages (0.3.233).
     #
-    # Was ==0.3.233, which sat BELOW agent-baselines' >=0.3.249 floor. When the
-    # eval overlays this package (`uv run --project solvers/inspect-swe --with
-    # asta-bench-private`), the hard `==` pin won over agent-baselines'
-    # override-dependencies and pulled the solve env down to 0.3.233, so
-    # inspect_swe's newer `checkpointer` call crashed with
+    # Why this is not an exact pin: agent-baselines is Ai2's collection of
+    # reference solver integrations. Its inspect-swe integration runs coding
+    # agents such as Claude Code and Codex inside an Inspect sandbox. Current
+    # versions need a newer inspect_ai API (`>=0.3.249`) for the sandbox
+    # `checkpointer` argument. The former exact `==0.3.233` requirement forced
+    # that solver back to an incompatible version and crashed with
     # `sandbox_agent_bridge() got an unexpected keyword argument 'checkpointer'`.
-    # Relaxing this to the shared floor is the fix.
-    #
-    # NOTE: >=0.3.249's Anthropic provider requires anthropic>=0.105 (see the
-    # anthropic floor below); the agent-baselines lock carries that via #32.
-    # The SCORER's inspect_ai pin (solvers/scorer/pyproject.toml, 0.3.225) is
-    # intentionally NOT bumped here — raising it risks changing scoring logic
-    # and is done only reactively when a solve-arm event type can't be read.
-    # See gas2own#346, gas2own#430, allenai/agent-baselines#31 and #32.
-    "inspect_ai>=0.3.249",
+    # This lower bound lets that and other solvers declare their own stricter
+    # requirements. The scorer remains independently pinned; see
+    # solvers/scorer/pyproject.toml.
+    # See gas2own#346, gas2own#430, and allenai/agent-baselines#32.
+    "inspect_ai>=0.3.233",
     # Base agent-eval is the inspect-free solve contract (suite config,
     # EvalConfig, and git reproducibility helpers). Scoring dependencies,
     # including inspect_ai==0.3.203, live in agent-eval's scoring/leaderboard
@@ -56,11 +50,6 @@ dependencies = [
     "h2~=4.2.0",
     "pandas",
     "scipy",
-    # NB: inspect_ai>=0.3.249's Anthropic provider requires anthropic>=0.105 at
-    # runtime. This floor permits it (the resolver picks a recent anthropic),
-    # and the frozen solve-env lock carries it explicitly via
-    # allenai/agent-baselines#32; not pinned tighter here to avoid churning the
-    # scorer env, which shares this dependency.
     "anthropic>=0.87.0",
     "platformdirs",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,32 @@ version = "0.5.4"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # 0.3.233 is the tightest version carrying both fixes required by the
-    # inspect-swe solve arm: bridged MCP result serialization (0.3.220) and
-    # inline Anthropic system-role messages (0.3.233). agent-baselines caps
-    # inspect_swe below 0.2.60 because newer versions declare a higher
-    # inspect_ai floor (and 0.2.65+ pass the newer `checkpointer` bridge API),
-    # while its uv override would otherwise force them onto incompatible
-    # 0.3.233.
-    # See gas2own#346 and allenai/agent-baselines#31.
-    "inspect_ai==0.3.233",
+    # SOLVE ARM inspect_ai floor. This is deliberately the shared floor that
+    # agent-baselines' inspect-swe declares (`inspect_ai>=0.3.249`), so the two
+    # cohere instead of fighting. The current Claude Code and Codex inspect_swe
+    # agents need >=0.3.249 for (a) the Anthropic sandbox bridge to accept a
+    # system-role message in `messages[]` (folded into ChatMessageSystem in
+    # messages_from_anthropic_input; older raised "Unexpected message role:
+    # system") and (b) the newer `checkpointer` bridge API that inspect_swe
+    # >=0.2.65 passes. Both earlier fixes this pin carried are still present at
+    # >=0.3.249: bridged MCP result serialization (0.3.220) and inline
+    # Anthropic system-role messages (0.3.233).
+    #
+    # Was ==0.3.233, which sat BELOW agent-baselines' >=0.3.249 floor. When the
+    # eval overlays this package (`uv run --project solvers/inspect-swe --with
+    # asta-bench-private`), the hard `==` pin won over agent-baselines'
+    # override-dependencies and pulled the solve env down to 0.3.233, so
+    # inspect_swe's newer `checkpointer` call crashed with
+    # `sandbox_agent_bridge() got an unexpected keyword argument 'checkpointer'`.
+    # Relaxing this to the shared floor is the fix.
+    #
+    # NOTE: >=0.3.249's Anthropic provider requires anthropic>=0.105 (see the
+    # anthropic floor below); the agent-baselines lock carries that via #32.
+    # The SCORER's inspect_ai pin (solvers/scorer/pyproject.toml, 0.3.225) is
+    # intentionally NOT bumped here — raising it risks changing scoring logic
+    # and is done only reactively when a solve-arm event type can't be read.
+    # See gas2own#346, gas2own#430, allenai/agent-baselines#31 and #32.
+    "inspect_ai>=0.3.249",
     # Base agent-eval is the inspect-free solve contract (suite config,
     # EvalConfig, and git reproducibility helpers). Scoring dependencies,
     # including inspect_ai==0.3.203, live in agent-eval's scoring/leaderboard
@@ -39,6 +56,11 @@ dependencies = [
     "h2~=4.2.0",
     "pandas",
     "scipy",
+    # NB: inspect_ai>=0.3.249's Anthropic provider requires anthropic>=0.105 at
+    # runtime. This floor permits it (the resolver picks a recent anthropic),
+    # and the frozen solve-env lock carries it explicitly via
+    # allenai/agent-baselines#32; not pinned tighter here to avoid churning the
+    # scorer env, which shares this dependency.
     "anthropic>=0.87.0",
     "platformdirs",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # SOLVE-ENVIRONMENT inspect_ai floor. The root astabench package is
     # installed alongside a participant's solver to provide the benchmark
     # tasks. It should declare the oldest inspect_ai API astabench itself needs
-    # and allow each solver to select a newer compatible version. Version
+    # and allow each solver to select a newer compatible 0.3.x version. Version
     # 0.3.233 is the oldest release carrying both fixes required by these
     # tasks: bridged MCP result serialization (0.3.220) and inline Anthropic
     # system-role messages (0.3.233).
@@ -24,10 +24,11 @@ dependencies = [
     # that solver back to an incompatible version and crashed with
     # `sandbox_agent_bridge() got an unexpected keyword argument 'checkpointer'`.
     # This lower bound lets that and other solvers declare their own stricter
-    # requirements. The scorer remains independently pinned; see
-    # solvers/scorer/pyproject.toml.
+    # requirements. The <0.4 ceiling avoids silently accepting a new API line;
+    # compatibility with 0.4 should be evaluated before widening the range.
+    # The scorer remains independently pinned; see solvers/scorer/pyproject.toml.
     # See gas2own#346, gas2own#430, and allenai/agent-baselines#32.
-    "inspect_ai>=0.3.233",
+    "inspect_ai>=0.3.233,<0.4",
     # Base agent-eval is the inspect-free solve contract (suite config,
     # EvalConfig, and git reproducibility helpers). Scoring dependencies,
     # including inspect_ai==0.3.203, live in agent-eval's scoring/leaderboard

--- a/solvers/scorer/uv.lock
+++ b/solvers/scorer/uv.lock
@@ -324,7 +324,7 @@ requires-dist = [
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.2" },
     { name = "huggingface-hub" },
-    { name = "inspect-ai", specifier = "==0.3.233" },
+    { name = "inspect-ai", specifier = ">=0.3.249" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "litellm", specifier = "==1.88.1" },
     { name = "mcp", specifier = "~=1.10" },

--- a/solvers/scorer/uv.lock
+++ b/solvers/scorer/uv.lock
@@ -324,7 +324,7 @@ requires-dist = [
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.2" },
     { name = "huggingface-hub" },
-    { name = "inspect-ai", specifier = ">=0.3.233" },
+    { name = "inspect-ai", specifier = ">=0.3.233,<0.4" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "litellm", specifier = "==1.88.1" },
     { name = "mcp", specifier = "~=1.10" },

--- a/solvers/scorer/uv.lock
+++ b/solvers/scorer/uv.lock
@@ -324,7 +324,7 @@ requires-dist = [
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.2" },
     { name = "huggingface-hub" },
-    { name = "inspect-ai", specifier = ">=0.3.249" },
+    { name = "inspect-ai", specifier = ">=0.3.233" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "litellm", specifier = "==1.88.1" },
     { name = "mcp", specifier = "~=1.10" },


### PR DESCRIPTION
## What

Changes the root `astabench` package's solve-environment requirement from `inspect_ai==0.3.233` to `inspect_ai>=0.3.233,<0.4`. The scorer remains independently pinned to `inspect_ai==0.3.225`.

## Terminology

- **AstaBench solve environment:** the environment where a participant's solver runs. The root `astabench` package is installed there to provide benchmark tasks.
- **agent-baselines:** Ai2's collection of reference solver integrations.
- **inspect-swe:** one of those integrations; it runs coding agents such as Claude Code and Codex inside an Inspect sandbox.

`agent-baselines/inspect-swe` is therefore an example of a solver consuming AstaBench, not part of AstaBench's scorer.

## Why the lower bound is `0.3.233`

`0.3.233` is the oldest Inspect release containing both behaviors the AstaBench tasks themselves require:

- bridged MCP result serialization, added in `0.3.220`; and
- inline Anthropic system-role messages, fixed in `0.3.233`.

That is AstaBench's minimum solve-time API contract. Individual solvers may require a newer Inspect version and should declare that themselves. For example, current `agent-baselines/inspect-swe` requires `>=0.3.249` for the sandbox `checkpointer` API used by current Claude Code and Codex integrations.

The former exact AstaBench pin overrode that solver requirement in the combined environment and forced Inspect back to `0.3.233`, causing:

```
TypeError: sandbox_agent_bridge() got an unexpected keyword argument 'checkpointer'
```

A lower bound preserves AstaBench's tested minimum while allowing the resolver to satisfy stricter solver requirements. It also avoids making one reference solver's current floor (`0.3.249`) AstaBench's floor for every solver.

## Why the upper bound is `<0.4`

The range is intentionally limited to the current `0.3.x` API line. AstaBench should not silently claim solve-time compatibility with a future `0.4` release; that boundary should be tested and reviewed before the range is widened.

## Scorer remains unchanged

The scorer (`solvers/scorer`) stays pinned to `inspect_ai==0.3.225`; changing its runtime could affect grading behavior. Its lockfile changes only to record the root package's relaxed requirement, and still resolves `inspect-ai==0.3.225` through the scorer's override.

## Validation

- `uv lock --check --project solvers/scorer`
- `git diff --check`

Refs allenai/gas2own#430 and allenai/agent-baselines#32.
