### PR TITLE
Fix Paper Finder LitQA2 grouped-metric collision

### DIFF
--- a/astabench/evals/paper_finder/task.py
+++ b/astabench/evals/paper_finder/task.py
@@ -152,9 +152,20 @@ def score_paper_finder() -> Scorer:
 
 
 def score_paper_finder_with_all_name(all_name: str) -> Callable:
+    # LitQA2 has a single score group named ``recall_at_30`` and also uses that
+    # name for its primary metric. Asking grouped() to add an all-samples row
+    # with the same label is ambiguous and newer Inspect versions reject it.
+    # Keep the group itself as the primary metric; multi-group Paper Finder
+    # Bench variants still receive their separately named aggregate row.
+    include_all_samples = all_name not in pf_group_score_names.values()
     return scorer(
         metrics=[
-            grouped(mean(), group_key="score_type", all="samples", all_label=all_name),
+            grouped(
+                mean(),
+                group_key="score_type",
+                all="samples" if include_all_samples else False,
+                all_label=all_name,
+            ),
             stderr(),
         ]
     )(score_paper_finder)

--- a/tests/test_paper_finder_metrics.py
+++ b/tests/test_paper_finder_metrics.py
@@ -1,0 +1,27 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import astabench.evals._registry  # noqa: E402, F401
+from inspect_ai.scorer import SampleScore, Score  # noqa: E402
+
+from astabench.evals.paper_finder.task import (  # noqa: E402
+    score_paper_finder_with_all_name,
+)
+
+
+def test_litqa2_primary_metric_does_not_collide_with_aggregate_label():
+    scorer = score_paper_finder_with_all_name("recall_at_30")()
+    grouped_mean = scorer.__registry_info__.metadata["metrics"][0]
+
+    result = grouped_mean(
+        [
+            SampleScore(
+                score=Score(value=1.0),
+                sample_id="litqa2_1",
+                sample_metadata={"score_type": "recall_at_30"},
+            )
+        ]
+    )
+
+    assert result == {"recall_at_30": 1.0}


### PR DESCRIPTION
Tracked by allenai/gas2own#417.

Paper Finder's LitQA2 task names its sole score group `recall_at_30` and also passed that label to `grouped()` for the all-samples aggregate. Inspect rejects the duplicate instead of silently overwriting one metric, so a completed Paper Finder solve could not be scored.

This disables the redundant aggregate only when its label collides with a real score group. The existing `recall_at_30` group remains the configured primary metric; multi-group Paper Finder Bench tasks keep their separately named aggregate unchanged.

Validation:

- regression test reproduces the exact one-sample LitQA2 grouping and returns `{"recall_at_30": 1.0}`
- Black 24.2.0
- Flake8 7.2.0 (`F` checks)
- `git diff --check`
