### PR TITLE
Bump agent-eval to 0.1.54

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,12 @@ dependencies = [
     # that solver back to an incompatible version and crashed with
     # `sandbox_agent_bridge() got an unexpected keyword argument 'checkpointer'`.
     # This lower bound lets that and other solvers declare their own stricter
-    # requirements. The <0.4 ceiling avoids silently accepting a new API line;
-    # compatibility with 0.4 should be evaluated before widening the range.
+    # requirements. The temporary <0.3.259 ceiling avoids Inspect releases
+    # that require OpenAI SDK >=3.1 while litellm==1.88.1 requires OpenAI <3.
+    # Restore the <0.4 ceiling once LiteLLM supports OpenAI 3.x.
     # The scorer remains independently pinned; see solvers/scorer/pyproject.toml.
     # See gas2own#346, gas2own#430, and allenai/agent-baselines#32.
-    "inspect_ai>=0.3.233,<0.4",
+    "inspect_ai>=0.3.233,<0.3.259",
     # Base agent-eval is the inspect-free solve contract (suite config,
     # EvalConfig, and git reproducibility helpers). Scoring dependencies,
     # including inspect_ai==0.3.203, live in agent-eval's scoring/leaderboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # EvalConfig, and git reproducibility helpers). Scoring dependencies,
     # including inspect_ai==0.3.203, live in agent-eval's scoring/leaderboard
     # extras and are installed only by solvers/scorer. See gas2own#346.
-    "agent-eval==0.1.53",
+    "agent-eval==0.1.54",
     "openai>=2.30.0", # provider SDK version validated with the current model set
     "pydantic>=2.11.4", # required by inspect
     "pyyaml", # scripts/task_metadatas.py parses suite .yml files directly

--- a/solvers/scorer/pyproject.toml
+++ b/solvers/scorer/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # Add agent-eval's scorer / leaderboard stack only in this isolated env.
     # Base astabench uses agent-eval's inspect-free contract; this extra adds the
     # frozen scoring Inspect version through the override below (gas2own#346).
-    "agent-eval[leaderboard]==0.1.53",
+    "agent-eval[leaderboard]==0.1.54",
     # Scorer Inspect must be >= every event type the solve arms can emit, or
     # read_eval_log rejects the log. It was 0.3.203, but interrupted samples
     # write an InterruptEvent (added in Inspect 0.3.225), which a 0.3.203 reader

--- a/solvers/scorer/uv.lock
+++ b/solvers/scorer/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "agent-eval"
-version = "0.1.53"
+version = "0.1.54"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -38,9 +38,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/98/43dfd99fa1f8c7b71f5bbe1e1505d5ae3206b9899979a09846755dbb1106/agent_eval-0.1.53.tar.gz", hash = "sha256:49581d9cdd50886299a3e4cf8073771eddf88b3c3e4cd18fcb513d7233951279", size = 51401, upload-time = "2026-07-29T20:38:33.277Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/5c/4fe2c8f40a632f9d98ae0f4108a40df1cdec8a369300bf638045cb7de909/agent_eval-0.1.54.tar.gz", hash = "sha256:4abcd86b2a92e171429dd270ba1fe201fc404bcbdc2c0a8fe1bea95eeaab6f0a", size = 51963, upload-time = "2026-09-03T17:14:41.538Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/2a/4414f9ba58e37d94aec07fd97e8d66989cb674d8d1a942a92495f27d8e27/agent_eval-0.1.53-py3-none-any.whl", hash = "sha256:4fb73ced33b031ea5dbcf75eb2092ee653d1c5a051cde01cc99f547fad3decfa", size = 45935, upload-time = "2026-07-29T20:38:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/2d/08faea0446c37090398d292b9b22ad31688e3b0f66f67475cb243927765b/agent_eval-0.1.54-py3-none-any.whl", hash = "sha256:0eb7065ad04ce858a0ca3e34c560cb9c880cc570cae0bf852f927179e08282aa", size = 46146, upload-time = "2026-09-03T17:14:40.447Z" },
 ]
 
 [package.optional-dependencies]
@@ -310,7 +310,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-eval", specifier = "==0.1.53" },
+    { name = "agent-eval", specifier = "==0.1.54" },
     { name = "anthropic", specifier = ">=0.87.0" },
     { name = "autoflake", marker = "extra == 'dev'" },
     { name = "azure-ai-inference", marker = "extra == 'azure'" },
@@ -357,7 +357,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-eval", extras = ["leaderboard"], specifier = "==0.1.53" },
+    { name = "agent-eval", extras = ["leaderboard"], specifier = "==0.1.54" },
     { name = "astabench", editable = "../../" },
     { name = "inspect-ai", specifier = "==0.3.225" },
 ]

--- a/solvers/scorer/uv.lock
+++ b/solvers/scorer/uv.lock
@@ -324,7 +324,7 @@ requires-dist = [
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.2" },
     { name = "huggingface-hub" },
-    { name = "inspect-ai", specifier = ">=0.3.233,<0.4" },
+    { name = "inspect-ai", specifier = ">=0.3.233,<0.3.259" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "litellm", specifier = "==1.88.1" },
     { name = "mcp", specifier = "~=1.10" },


### PR DESCRIPTION
## Summary
- bump `agent-eval` from 0.1.53 to 0.1.54 in the base and frozen scorer environments
- refresh `solvers/scorer/uv.lock`
- pick up pricing for `deepseek/deepseek-v4pro-preview` from allenai/agent-eval#87
- temporarily cap root `inspect_ai` below 0.3.259 because newer releases require OpenAI SDK 3.x while LiteLLM requires OpenAI below 3

## Verification
- `./scripts/smoke_solve_score.sh`
- rebuilt the Docker test image from a fresh dependency resolution: Inspect 0.3.258, OpenAI 2.54.0, LiteLLM 1.88.1
- verified `inspect_ai.model._providers.openai.OpenAIAPI` imports successfully in that image
- pytest collection succeeds for all 214 tests
- verified the published agent-eval 0.1.54 wheel exposes the preview-model rates and calculates $35.844 for 79.8M input and 1.3M output tokens